### PR TITLE
chore: bump blueprint-sdk to 0.2.0-alpha.1

### DIFF
--- a/{{project-name}}-bin/Cargo.toml
+++ b/{{project-name}}-bin/Cargo.toml
@@ -12,6 +12,6 @@ path = "src/main.rs"
 
 [dependencies]
 {{project-name}}-lib = { path = "../{{project-name}}-lib" }
-blueprint-sdk = { version = "0.1.0-alpha.22", default-features = false, features = ["std", "tangle"] }
+blueprint-sdk = { version = "0.2.0-alpha.1", default-features = false, features = ["std", "tangle"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/{{project-name}}-lib/Cargo.toml
+++ b/{{project-name}}-lib/Cargo.toml
@@ -7,11 +7,11 @@ description.workspace = true
 license.workspace = true
 
 [dependencies]
-blueprint-sdk = { version = "0.1.0-alpha.22", default-features = false, features = ["std", "tracing", "macros", "tangle"] }
+blueprint-sdk = { version = "0.2.0-alpha.1", default-features = false, features = ["std", "tracing", "macros", "tangle"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", default-features = false, features = ["sync"] }
 
 [dev-dependencies]
 anyhow = "1"
-blueprint-anvil-testing-utils = "0.1.0-alpha.21"
+blueprint-anvil-testing-utils = "0.2.0-alpha.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
Bump blueprint-sdk from 0.1.0-alpha.22 to 0.2.0-alpha.1 and blueprint-anvil-testing-utils from 0.1.0-alpha.21 to 0.2.0-alpha.1.