### PR TITLE
chore(soldeer): bump tnt-core to 0.10.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ and follow the instructions to create a new project.
 ```
 {{project-name}}/
   Cargo.toml              # Workspace configuration
+  metadata/               # Offchain blueprint metadata published to IPFS/HTTPS
+    blueprint-metadata.json
   {{project-name}}-lib/   # Blueprint library with job definitions
     src/lib.rs            # Job implementation and router
   {{project-name}}-bin/   # Blueprint runner binary
@@ -80,6 +82,42 @@ Deploy the blueprint to the Tangle network:
 ```sh
 cargo tangle blueprint deploy tangle --network devnet
 ```
+
+## Hosted App Metadata
+
+The onchain registry only stores a `metadata_uri` pointer. The rich blueprint
+JSON itself lives offchain, usually on IPFS or a versioned HTTPS endpoint.
+
+This template includes a starter file at
+`metadata/blueprint-metadata.json`. It contains:
+
+- top-level blueprint metadata such as `name`, `description`, and `author`
+- a `blueprintUi` contract used by Tangle Cloud's shared host
+- starter tier-2 modules for cards, schema-driven actions, resource views,
+  theme tokens, and approved host modules
+
+Recommended workflow:
+
+1. Edit `metadata/blueprint-metadata.json` so the content matches your
+   blueprint's public UX contract.
+2. Publish the JSON to IPFS for immutable production hosting, or to HTTPS for
+   local development and previews.
+3. Set the resulting URI as `metadata_uri` in your deploy definition.
+4. Register or update the blueprint onchain with that URI.
+
+For hardened tier-2 hosting, add an `integrity` attestation before publishing:
+
+- compute a payload hash over the metadata JSON without the `integrity` field
+- bind that hash to `blueprintId`, `owner`, and `metadata_uri`
+- sign the attestation with the onchain blueprint owner's EVM key
+- publish the signature alongside the metadata JSON
+
+If attestation verification fails, Tangle Cloud falls back to the default
+protocol host instead of rendering advanced tier-2 features.
+
+Tier 2 hosted apps are declarative on purpose. The shared host will parse and
+render configuration from `blueprintUi`, but it does not execute arbitrary
+third-party frontend code inside Tangle Cloud.
 
 ## Key Concepts
 

--- a/contracts/src/HelloBlueprint.sol
+++ b/contracts/src/HelloBlueprint.sol
@@ -15,15 +15,12 @@ contract HelloBlueprint is BlueprintServiceManagerBase {
      * @param operator The operator's address.
      * @param registrationInputs Inputs required for registration in bytes format.
      */
-    function onRegister(
-        address operator,
-        bytes calldata registrationInputs
-    )
-    external
-    payable
-    virtual
-    override
-    onlyFromTangle
+    function onRegister(address operator, bytes calldata registrationInputs)
+        external
+        payable
+        virtual
+        override
+        onlyFromTangle
     {
         // Do something with the operator's details
     }
@@ -40,13 +37,7 @@ contract HelloBlueprint is BlueprintServiceManagerBase {
         uint64 ttl,
         address paymentAsset,
         uint256 amount
-    )
-    external
-    payable
-    virtual
-    override
-    onlyFromTangle
-    {
+    ) external payable virtual override onlyFromTangle {
         // Do something with the service request
     }
 
@@ -67,13 +58,7 @@ contract HelloBlueprint is BlueprintServiceManagerBase {
         address operator,
         bytes calldata inputs,
         bytes calldata outputs
-    )
-    external
-    payable
-    virtual
-    override
-    onlyFromTangle
-    {
+    ) external payable virtual override onlyFromTangle {
         // Do something with the job call result
     }
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -14,6 +14,6 @@ remappings_location = "txt"
 remappings_version = false
 
 [dependencies]
-tnt-core = "0.10.8"
+tnt-core = "0.10.9"
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/foundry.toml
+++ b/foundry.toml
@@ -14,6 +14,6 @@ remappings_location = "txt"
 remappings_version = false
 
 [dependencies]
-tnt-core = "0.10.7"
+tnt-core = "0.10.8"
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/foundry.toml
+++ b/foundry.toml
@@ -14,6 +14,6 @@ remappings_location = "txt"
 remappings_version = false
 
 [dependencies]
-tnt-core = "0.10.3"
+tnt-core = "0.10.7"
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/metadata/blueprint-metadata.json
+++ b/metadata/blueprint-metadata.json
@@ -1,0 +1,124 @@
+{
+  "name": "{{project-name}}",
+  "description": "{{project-description}}",
+  "author": "{{project-authors}}",
+  "category": "Other",
+  "image": null,
+  "website": null,
+  "codeRepository": null,
+  "docs": null,
+  "integrity": null,
+  "blueprintUi": {
+    "displayName": "{{project-name}}",
+    "description": "{{project-description}}",
+    "requestedSlug": "{{project-name}}",
+    "publisher": {
+      "name": "{{project-authors}}",
+      "verified": false
+    },
+    "resources": {
+      "serviceLabel": "Service",
+      "itemLabel": "Run",
+      "itemRoute": "runs"
+    },
+    "surfaces": {
+      "genericOverview": true,
+      "serviceExplorer": true,
+      "actionsPanel": true,
+      "resources": true,
+      "metrics": true,
+      "permissions": true
+    },
+    "theme": {
+      "badgeLabel": "Hosted on Tangle Cloud",
+      "accentColor": "#0F766E",
+      "secondaryColor": "#0F172A",
+      "icon": "bot"
+    },
+    "overviewCards": [
+      {
+        "id": "operator-health",
+        "kind": "stat",
+        "title": "Operator health",
+        "description": "Shared host card summarizing operator and service activity.",
+        "value": "99.9%",
+        "tone": "success"
+      },
+      {
+        "id": "operator-links",
+        "kind": "links",
+        "title": "Useful links",
+        "links": [
+          {
+            "label": "Docs",
+            "href": "https://docs.tangle.tools/"
+          }
+        ]
+      }
+    ],
+    "actions": [
+      {
+        "id": "provision-service",
+        "label": "Provision service",
+        "description": "Schema-driven request form rendered inside the shared host.",
+        "target": "service",
+        "submitLabel": "Provision",
+        "fields": [
+          {
+            "key": "service_name",
+            "label": "Service name",
+            "input": "text",
+            "required": true,
+            "placeholder": "atlas-prod"
+          },
+          {
+            "key": "replicas",
+            "label": "Replicas",
+            "input": "number",
+            "required": true,
+            "placeholder": "3"
+          }
+        ]
+      }
+    ],
+    "resourceViews": [
+      {
+        "id": "runs-table",
+        "title": "Run ledger",
+        "kind": "table",
+        "target": "resource",
+        "defaultSort": "updated_at:desc",
+        "columns": [
+          {
+            "key": "status",
+            "label": "Status",
+            "emphasis": true
+          },
+          {
+            "key": "updated_at",
+            "label": "Updated"
+          }
+        ]
+      }
+    ],
+    "modules": [
+      {
+        "module": "metrics-overview",
+        "slot": "overview",
+        "metricKeys": [
+          "success_rate",
+          "latency_p95"
+        ]
+      },
+      {
+        "module": "resource-events",
+        "slot": "resources",
+        "eventKinds": [
+          "queued",
+          "started",
+          "completed"
+        ]
+      }
+    ]
+  }
+}

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,3 +1,3 @@
-@openzeppelin/contracts-upgradeable/=dependencies/tnt-core-0.10.3/dependencies/@openzeppelin-contracts-upgradeable-5.1.0/
-@openzeppelin/contracts/=dependencies/tnt-core-0.10.3/dependencies/@openzeppelin-contracts-5.1.0/
-tnt-core/=dependencies/tnt-core-0.10.3/
+@openzeppelin/contracts-upgradeable/=dependencies/tnt-core-0.10.9/dependencies/@openzeppelin-contracts-upgradeable-5.1.0/
+@openzeppelin/contracts/=dependencies/tnt-core-0.10.9/dependencies/@openzeppelin-contracts-5.1.0/
+tnt-core/=dependencies/tnt-core-0.10.9/

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -1,6 +1,6 @@
 [[dependencies]]
 name = "tnt-core"
-version = "0.10.3"
-url = "https://soldeer-revisions.s3.amazonaws.com/tnt-core/0_10_3_21-02-2026_18:36:47_tnt-core.zip"
-checksum = "220f7aec5cae6ee8e189ce1b911de746193cdcc31f14644e02b59548d878aad1"
-integrity = "756c4d3a9a3af06c44c37b9c37573a8907ed29b7a3756743c03fd17ef57ad9ea"
+version = "0.10.9"
+url = "https://soldeer-revisions.s3.amazonaws.com/tnt-core/0_10_9_24-04-2026_03:56:11_tnt-core.zip"
+checksum = "d7a5b2c0dd620a2801d300680d599535fab9128e3c30ca9c8f43b8dfdf2b5c0c"
+integrity = "02bb7d7371ce17f6c82141cb62589d598e3f3db92a632336c11e4c4207a1aa76"

--- a/{{project-name}}-bin/Cargo.toml
+++ b/{{project-name}}-bin/Cargo.toml
@@ -12,6 +12,6 @@ path = "src/main.rs"
 
 [dependencies]
 {{project-name}}-lib = { path = "../{{project-name}}-lib" }
-blueprint-sdk = { version = "0.1.0-alpha.22", default-features = false, features = ["std", "tangle"] }
+blueprint-sdk = { version = "0.2.0-alpha.1", default-features = false, features = ["std", "tangle"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/{{project-name}}-bin/src/main.rs
+++ b/{{project-name}}-bin/src/main.rs
@@ -1,16 +1,13 @@
 //! Blueprint runner for {{project-name}}.
 
-use {{crate_name}}_lib::router;
 use blueprint_sdk::contexts::tangle::TangleClientContext;
-use blueprint_sdk::crypto::tangle_pair_signer::TanglePairSigner;
-use blueprint_sdk::keystore::backends::Backend;
-use blueprint_sdk::keystore::crypto::sp_core::SpSr25519;
 use blueprint_sdk::runner::BlueprintRunner;
 use blueprint_sdk::runner::config::BlueprintEnvironment;
 use blueprint_sdk::runner::tangle::config::TangleConfig;
 use blueprint_sdk::tangle::consumer::TangleConsumer;
 use blueprint_sdk::tangle::producer::TangleProducer;
 use blueprint_sdk::{error, info};
+use {{crate_name}}_lib::router;
 
 #[tokio::main]
 async fn main() -> Result<(), blueprint_sdk::Error> {
@@ -25,17 +22,6 @@ async fn main() -> Result<(), blueprint_sdk::Error> {
         .await
         .map_err(|e| blueprint_sdk::Error::Other(e.to_string()))?;
 
-    // Build signer used for submitting job results.
-    let sr25519_signer = env
-        .keystore()
-        .first_local::<SpSr25519>()
-        .map_err(|e| blueprint_sdk::Error::Other(e.to_string()))?;
-    let sr25519_pair = env
-        .keystore()
-        .get_secret::<SpSr25519>(&sr25519_signer)
-        .map_err(|e| blueprint_sdk::Error::Other(e.to_string()))?;
-    let tangle_signer = TanglePairSigner::new(sr25519_pair.0);
-
     // Get service ID from protocol settings
     let service_id = env
         .protocol_settings
@@ -47,10 +33,8 @@ async fn main() -> Result<(), blueprint_sdk::Error> {
     info!("Starting {{project-name}} blueprint for service {service_id}");
 
     // Create producer (listens for JobSubmitted events) and consumer (submits results)
-    let tangle_producer = TangleProducer::finalized_blocks(tangle_client.rpc_client.clone())
-        .await
-        .map_err(|e| blueprint_sdk::Error::Other(e.to_string()))?;
-    let tangle_consumer = TangleConsumer::new(tangle_client.rpc_client.clone(), tangle_signer);
+    let tangle_producer = TangleProducer::new(tangle_client.clone(), service_id);
+    let tangle_consumer = TangleConsumer::new(tangle_client);
     let tangle_config = TangleConfig::default();
 
     // Build and run the blueprint

--- a/{{project-name}}-lib/Cargo.toml
+++ b/{{project-name}}-lib/Cargo.toml
@@ -7,8 +7,8 @@ description.workspace = true
 license.workspace = true
 
 [dependencies]
+alloy-sol-types = "1.3"
 blueprint-sdk = { version = "0.2.0-alpha.1", default-features = false, features = ["std", "tracing", "macros", "tangle"] }
-serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", default-features = false, features = ["sync"] }
 
 [dev-dependencies]

--- a/{{project-name}}-lib/Cargo.toml
+++ b/{{project-name}}-lib/Cargo.toml
@@ -7,11 +7,11 @@ description.workspace = true
 license.workspace = true
 
 [dependencies]
-blueprint-sdk = { version = "0.1.0-alpha.22", default-features = false, features = ["std", "tracing", "macros", "tangle"] }
+blueprint-sdk = { version = "0.2.0-alpha.1", default-features = false, features = ["std", "tracing", "macros", "tangle"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", default-features = false, features = ["sync"] }
 
 [dev-dependencies]
 anyhow = "1"
-blueprint-anvil-testing-utils = "0.1.0-alpha.21"
+blueprint-anvil-testing-utils = "0.2.0-alpha.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/{{project-name}}-lib/src/lib.rs
+++ b/{{project-name}}-lib/src/lib.rs
@@ -1,26 +1,29 @@
 //! {{project-description}}
 
+use alloy_sol_types::sol;
 use blueprint_sdk::Router;
+use blueprint_sdk::macros::debug_job;
 use blueprint_sdk::tangle::extract::{Caller, TangleArg, TangleResult};
-use serde::{Deserialize, Serialize};
+use std::fmt::Write as _;
 
 /// Job ID for the hello job.
 pub const HELLO_JOB_ID: u8 = 0;
 
-/// Input payload sent from the Tangle contract.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct HelloRequest {
-    pub name: String,
-}
+sol! {
+    /// Input payload sent from the Tangle contract.
+    struct HelloRequest {
+        string name;
+    }
 
-/// Output payload returned back to the caller.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct HelloResponse {
-    pub message: String,
-    pub operator: String,
+    /// Output payload returned back to the caller.
+    struct HelloResponse {
+        string message;
+        string operator;
+    }
 }
 
 /// A simple job that greets the caller.
+#[debug_job]
 pub async fn hello(
     Caller(caller): Caller,
     TangleArg(request): TangleArg<HelloRequest>,
@@ -29,8 +32,17 @@ pub async fn hello(
 
     TangleResult(HelloResponse {
         message,
-        operator: caller.to_string(),
+        operator: format_caller(&caller),
     })
+}
+
+fn format_caller(caller: &[u8; 20]) -> String {
+    let mut encoded = String::with_capacity(42);
+    encoded.push_str("0x");
+    for byte in caller {
+        write!(&mut encoded, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    encoded
 }
 
 /// Router that maps job IDs to handlers.
@@ -45,12 +57,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_hello() {
-        let caller = [0u8; 32].into();
+        let caller = [0u8; 20].into();
         let request = HelloRequest {
             name: "World".to_string(),
         };
 
         let result = hello(Caller(caller), TangleArg(request)).await;
         assert!(result.0.message.contains("Hello, World!"));
+        assert_eq!(
+            result.0.operator,
+            "0x0000000000000000000000000000000000000000"
+        );
     }
 }


### PR DESCRIPTION
Bumps the template Soldeer dependency, lockfile, and remappings to tnt-core 0.10.9.

Also adds the hosted app metadata starter and README workflow docs for tier-2 hosted blueprint UIs, formats the Solidity template, and fixes the generated Rust blueprint project so the template passes `cargo check` with blueprint-sdk 0.2.0-alpha.1.

Verification:
- jq empty metadata/blueprint-metadata.json
- forge fmt --check
- forge build
- generated template project: cargo fmt --check
- generated template project: cargo check
