### PR TITLE
chore(deps): bump blueprint-sdk to v0.2.0-alpha.5

### DIFF
--- a/.github/workflows/verify-template.yml
+++ b/.github/workflows/verify-template.yml
@@ -27,7 +27,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.88"
+          toolchain: "1.91"
       - name: Copy generated project
         run: cp -r $PROJECT_NAME ${{ runner.temp }}/
       - name: Forge build

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.88"
+channel = "1.91"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/{{project-name}}-bin/Cargo.toml
+++ b/{{project-name}}-bin/Cargo.toml
@@ -12,6 +12,6 @@ path = "src/main.rs"
 
 [dependencies]
 {{project-name}}-lib = { path = "../{{project-name}}-lib" }
-blueprint-sdk = { version = "0.2.0-alpha.1", default-features = false, features = ["std", "tangle"] }
+blueprint-sdk = { version = "0.2.0-alpha.5", default-features = false, features = ["std", "tangle"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/{{project-name}}-lib/Cargo.toml
+++ b/{{project-name}}-lib/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 
 [dependencies]
 alloy-sol-types = "1.3"
-blueprint-sdk = { version = "0.2.0-alpha.1", default-features = false, features = ["std", "tracing", "macros", "tangle"] }
+blueprint-sdk = { version = "0.2.0-alpha.5", default-features = false, features = ["std", "tracing", "macros", "tangle"] }
 tokio = { version = "1", default-features = false, features = ["sync"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Picks up the audit follow-up batch (M-2 / H-1 / F-001 + governance-tunable operator cap) via tnt-core-bindings v0.17.1.